### PR TITLE
Ignore insecure files when initializing command completion for zsh

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -13,7 +13,7 @@ smithy () {
 
 if [[ -n ${ZSH_VERSION-} ]]; then
   fpath=($SMITHY_PREFIX/lib/app/etc/completion/zsh $fpath)
-  compinit
+  compinit -i
 fi
 
 if [[ -n ${BASH_VERSION-} ]]; then


### PR DESCRIPTION
Without this update, zsh users may get this warning when sourcing
environment.sh:

```
$ . /sw/tools/smithy/environment.sh
zsh compinit: insecure directories and files, run compaudit for list.
Ignore insecure directories and files and continue [y] or abort compinit [n]?
compinit: initialization aborted
==> Reindexing packages
$
```
