### PR TITLE
Allow installation of versions containing a "-"

### DIFF
--- a/lib/smithy/formula_command.rb
+++ b/lib/smithy/formula_command.rb
@@ -113,7 +113,7 @@ module Smithy
       formula_constant_name = "#{formula_name.underscore.camelize}Formula"
 
       if version.present?
-        version_concern = "Version" + version.gsub(/\./, "_")
+        version_concern = "Version" + version.gsub(/[.-]/, "_")
         if formula_constant_name.constantize.const_defined?(version_concern)
           formula_constant_name.constantize.class_eval "include #{version_concern}"
         end


### PR DESCRIPTION
Avoid error caused by creating a constant with an invalid name when installing a version containing a "-".